### PR TITLE
ignore reading share permissions on start-path / root level.

### DIFF
--- a/src/com/google/enterprise/adaptor/fs/FsAdaptor.java
+++ b/src/com/google/enterprise/adaptor/fs/FsAdaptor.java
@@ -227,6 +227,9 @@ public class FsAdaptor extends AbstractAdaptor {
   private static final String CONFIG_SKIP_SHARE_ACL = 
       "filesystemadaptor.skipShareAccessControl";
 
+  private static final String CONFIG_SKIP_SHARE_ACL_ON_ROOT_IF_ERROR =
+      "filesystemadaptor.skipShareAccessControlOnStartPathOnError";
+
   /** The config parameter name for the prefix for BUILTIN groups. */
   private static final String CONFIG_BUILTIN_PREFIX =
       "filesystemadaptor.builtinGroupPrefix";
@@ -287,6 +290,7 @@ public class FsAdaptor extends AbstractAdaptor {
   private AdaptorContext context;
   private FileDelegate delegate;
   private boolean skipShareAcl;
+  private boolean skipShareAclOnRootIfError;
   private boolean monitorForUpdates;
 
   /** The set of file systems we will be traversing. */
@@ -342,6 +346,7 @@ public class FsAdaptor extends AbstractAdaptor {
     config.addKey(CONFIG_BUILTIN_PREFIX, "BUILTIN\\");
     config.addKey(CONFIG_NAMESPACE, Principal.DEFAULT_NAMESPACE);
     config.addKey(CONFIG_SKIP_SHARE_ACL, "false");
+    config.addKey(CONFIG_SKIP_SHARE_ACL_ON_ROOT_IF_ERROR, "false");
     config.addKey(CONFIG_CRAWL_HIDDEN_FILES, "false");
     config.addKey(CONFIG_DIRECTORY_CACHE_SIZE, "50000");
     config.addKey(CONFIG_LAST_ACCESSED_DAYS, "");
@@ -393,6 +398,10 @@ public class FsAdaptor extends AbstractAdaptor {
     skipShareAcl = Boolean.parseBoolean(
         config.getValue(CONFIG_SKIP_SHARE_ACL));
     log.log(Level.CONFIG, "skipShareAcl: {0}", skipShareAcl);
+
+    skipShareAclOnRootIfError = Boolean.parseBoolean(
+            config.getValue(CONFIG_SKIP_SHARE_ACL_ON_ROOT_IF_ERROR));
+    log.log(Level.CONFIG, "skipShareAclOnRootIfError: {0}", skipShareAclOnRootIfError);
 
     // Add filters that may exclude older content.
     lastAccessTimeFilter = getFileTimeFilter(config,
@@ -472,7 +481,8 @@ public class FsAdaptor extends AbstractAdaptor {
   }
 
   /** Verify that a startPath is valid. */
-  private void validateStartPath(Path startPath, boolean logging)
+  @VisibleForTesting
+  void validateStartPath(Path startPath, boolean logging)
       throws IOException, InvalidConfigurationException {
     try {
       delegate.newDocId(startPath);
@@ -573,11 +583,16 @@ public class FsAdaptor extends AbstractAdaptor {
       readShareAcls(sharePath);
       delegate.getAclViews(sharePath);
     } catch (IOException e) {
-      throw new IOException("Unable to read ACLs for " + sharePath
-          + ". This can happen if the Windows account used to crawl "
-          + "the path does not have sufficient permissions. A Windows "
-          + "account with sufficient permissions to read content, "
-          + "attributes and ACLs is required to crawl a path.", e);
+      final boolean isRoot = startPaths.contains(sharePath) || delegate.isDfsLink(sharePath);
+      if (isRoot && skipShareAclOnRootIfError) {
+        log.fine("Unable to read ACLs for start path " + sharePath + " skipping acl detection.");
+      } else {
+        throw new IOException("Unable to read ACLs for " + sharePath
+                + ". This can happen if the Windows account used to crawl "
+                + "the path does not have sufficient permissions. A Windows "
+                + "account with sufficient permissions to read content, "
+                + "attributes and ACLs is required to crawl a path.", e);
+      }
     }
   }
 

--- a/test/com/google/enterprise/adaptor/fs/FsAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/fs/FsAdaptorTest.java
@@ -259,6 +259,19 @@ public class FsAdaptorTest {
     assertEquals(expected, adaptor.getStartPaths(dir, ""));
   }
 
+
+  @Test
+  public void testValidateStartPathsWithException()  {
+    Path dir = getPath("\\\\blubb\\gibtsnicht");
+    try {
+      adaptor.validateStartPath(dir, false);
+    } catch (IOException e) {
+      fail("validation failed");
+    } catch (com.google.enterprise.adaptor.InvalidConfigurationException e) {
+      // no problem
+    }
+  }
+
   @Test
   public void testGetStartPathsDefaultSeparator() throws Exception {
     String dir1 = getPath("dir1").toString();


### PR DESCRIPTION
Sometimes it could be that you do not have the permission to read the acls/permissions on share-path / root level. Typically this could happen if you want to index an NetApp share. This fix ignores acl validation errors on root level. The fix is triggerable by configuration.
