### PR TITLE
Fix b/31823871: Allow DFS Namespaces to have regular files and folders.

### DIFF
--- a/logging.properties
+++ b/logging.properties
@@ -1,9 +1,14 @@
-handlers = java.util.logging.ConsoleHandler
+handlers = java.util.logging.ConsoleHandler,java.util.logging.FileHandler
 .level = INFO
 com.google.enterprise.adaptor.sites.level = ALL
-com.google.enterprise.adaptor.level = FINER
+com.google.enterprise.adaptor.level = FINEST
 java.util.logging.ConsoleHandler.level = FINEST
 java.util.logging.ConsoleHandler.formatter = com.google.enterprise.adaptor.CustomFormatter
 # Uncomment if your terminal can't handle colors and the auto-detection
 # is incorrect.
 # com.google.enterprise.adaptor.CustomFormatter.useColor = false
+
+java.util.logging.FileHandler.formatter=com.google.enterprise.adaptor.CustomFormatter
+java.util.logging.FileHandler.pattern=logs/adaptor.%g.log
+java.util.logging.FileHandler.limit=10485760
+java.util.logging.FileHandler.count=5

--- a/logging.properties
+++ b/logging.properties
@@ -1,14 +1,9 @@
-handlers = java.util.logging.ConsoleHandler,java.util.logging.FileHandler
+handlers = java.util.logging.ConsoleHandler
 .level = INFO
 com.google.enterprise.adaptor.sites.level = ALL
-com.google.enterprise.adaptor.level = FINEST
+com.google.enterprise.adaptor.level = FINER
 java.util.logging.ConsoleHandler.level = FINEST
 java.util.logging.ConsoleHandler.formatter = com.google.enterprise.adaptor.CustomFormatter
 # Uncomment if your terminal can't handle colors and the auto-detection
 # is incorrect.
 # com.google.enterprise.adaptor.CustomFormatter.useColor = false
-
-java.util.logging.FileHandler.formatter=com.google.enterprise.adaptor.CustomFormatter
-java.util.logging.FileHandler.pattern=logs/adaptor.%g.log
-java.util.logging.FileHandler.limit=10485760
-java.util.logging.FileHandler.count=5

--- a/src/com/google/enterprise/adaptor/fs/FsAdaptor.java
+++ b/src/com/google/enterprise/adaptor/fs/FsAdaptor.java
@@ -685,9 +685,10 @@ public class FsAdaptor extends AbstractAdaptor {
   private void validateShare(Path sharePath) throws IOException {
     // Verify that the adaptor has permission to read the contents of the root.
     try {
-      if (delegate.isDfsNamespace(sharePath) && !allowFilesInDfsNamespaces) {
+      if (delegate.isDfsNamespace(sharePath)) {
         delegate.enumerateDfsLinks(sharePath);
-      } else {
+      }
+      if (!delegate.isDfsNamespace(sharePath) || allowFilesInDfsNamespaces) {
         delegate.newDirectoryStream(sharePath).close();
       }
     } catch (AccessDeniedException e) {

--- a/src/com/google/enterprise/adaptor/fs/FsAdaptor.java
+++ b/src/com/google/enterprise/adaptor/fs/FsAdaptor.java
@@ -714,7 +714,7 @@ public class FsAdaptor extends AbstractAdaptor {
     // Verify that the adaptor has permission to read the Acl and share Acl.
     try {
       readShareAcls(sharePath);
-      if (delegate.isDfsNamespace(sharePath) && allowFilesInDfsNamespaces) {
+      if (!delegate.isDfsNamespace(sharePath) || allowFilesInDfsNamespaces) {
         delegate.getAclViews(sharePath);
       }
     } catch (IOException e) {

--- a/src/com/google/enterprise/adaptor/fs/FsAdaptor.java
+++ b/src/com/google/enterprise/adaptor/fs/FsAdaptor.java
@@ -433,7 +433,7 @@ public class FsAdaptor extends AbstractAdaptor {
     config.addKey(CONFIG_MONITOR_UPDATES, "true");
     config.addKey(CONFIG_STATUS_UPDATE_INTERVAL_MINS, "15");
     config.addKey(CONFIG_SEARCH_RESULTS_GO_TO_REPO, "true");
-    // TODO (bmj): should this default to true?
+    // TODO(bmj): should this default to true?
     config.addKey(CONFIG_DFS_NAMESPACE_AS_DIRECTORY, "false");
     // Increase the max feed size, which also increases the
     // asyncDocIdSenderQueueSize to 40,000 entries. This would

--- a/test/com/google/enterprise/adaptor/fs/MockFileDelegate.java
+++ b/test/com/google/enterprise/adaptor/fs/MockFileDelegate.java
@@ -15,7 +15,9 @@
 package com.google.enterprise.adaptor.fs;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.enterprise.adaptor.AsyncDocIdPusher;
 import com.google.enterprise.adaptor.DocId;
 
@@ -181,7 +183,13 @@ class MockFileDelegate implements FileDelegate {
   public List<Path> enumerateDfsLinks(Path doc) throws IOException {
     MockFile file = getFile(doc);
     if (file.isDfsNamespace()) {
-      return ImmutableList.copyOf(file.newDirectoryStream());
+      ImmutableList.Builder<Path> builder = ImmutableList.builder();
+      for (Path path : file.newDirectoryStream()) {
+        if (isDfsLink(path)) {
+          builder.add(path);
+        }
+      }
+      return builder.build();
     } else {
       throw new IOException("Not a DFS Root: " + doc);
     }


### PR DESCRIPTION
This change adds a configuration parameter,
"filesystemadaptor.allowFilesInDfsNamespaces", that treats DFS Namespaces
like ordinary directories in getDocContent(). This returns ordinary files
and folders that may reside in the Namespace, as well as DFS Links.