### PR TITLE
Change the interface for enumerating DFS Links to DirectoryStream

### DIFF
--- a/src/com/google/enterprise/adaptor/fs/FileDelegate.java
+++ b/src/com/google/enterprise/adaptor/fs/FileDelegate.java
@@ -211,8 +211,7 @@ interface FileDelegate {
    * Helper class for wrapping a collection of {@link Path} as a
    * {@link DirectoryStream}.
    */
-  static class PathDirectoryStream
-      implements DirectoryStream<Path> {
+  static class PathDirectoryStream implements DirectoryStream<Path> {
     private final Iterable<Path> paths;
     private boolean mayGetIterator = true;
 

--- a/src/com/google/enterprise/adaptor/fs/FileDelegate.java
+++ b/src/com/google/enterprise/adaptor/fs/FileDelegate.java
@@ -211,15 +211,13 @@ interface FileDelegate {
    * Helper class for wrapping a collection of {@link Path} as a
    * {@link DirectoryStream}.
    */
-  abstract static class PathDirectoryStream
+  static class PathDirectoryStream
       implements DirectoryStream<Path> {
     private final Iterable<Path> paths;
     private boolean mayGetIterator = true;
 
-    public abstract Iterable<Path> getPaths() throws IOException;
-
-    PathDirectoryStream() throws IOException {
-      paths = getPaths();
+    PathDirectoryStream(Iterable<Path> paths) {
+      this.paths = paths;
     }
 
     @Override

--- a/src/com/google/enterprise/adaptor/fs/FileDelegate.java
+++ b/src/com/google/enterprise/adaptor/fs/FileDelegate.java
@@ -25,7 +25,6 @@ import java.nio.file.Path;
 import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
-import java.util.List;
 
 interface FileDelegate {
   /**
@@ -136,15 +135,15 @@ interface FileDelegate {
   Path resolveDfsLink(Path doc) throws IOException;
 
   /**
-   * Returns a list of DFS links contained within a DFS namespace.
-   * The supplied path would typically be like
+   * Returns a {@link DirectoryStream} of DFS links contained within a
+   * DFS namespace. The supplied path would typically be like
    * {@code \\\\server\\namespace} or {@code \\\\domain\\namespace}.
    *
    * @param doc the DFS UNC path to a DFS namespace
-   * @returns a List of DFS link paths
+   * @returns a DirectoryStream of DFS link paths
    * @throws IOException if doc is not a DFS namespace or is not accessable
    */
-  List<Path> enumerateDfsLinks(Path doc) throws IOException;
+  DirectoryStream<Path> newDfsLinkStream(Path doc) throws IOException;
 
   /**
    * Returns an {@link AclFileAttributeViews} that contains the directly

--- a/src/com/google/enterprise/adaptor/fs/FileDelegate.java
+++ b/src/com/google/enterprise/adaptor/fs/FileDelegate.java
@@ -211,15 +211,19 @@ interface FileDelegate {
    * Helper class for wrapping a collection of {@link Path} as a
    * {@link DirectoryStream}.
    */
-  abstract static class AbstractPathDirectoryStream
+  abstract static class PathDirectoryStream
       implements DirectoryStream<Path> {
-    protected Iterable<Path> paths;
+    private final Iterable<Path> paths;
     private boolean mayGetIterator = true;
+
+    public abstract Iterable<Path> getPaths() throws IOException;
+
+    PathDirectoryStream() throws IOException {
+      paths = getPaths();
+    }
 
     @Override
     public Iterator<Path> iterator() {
-      Preconditions.checkState(paths != null,
-          "Iterable paths field must be set.");
       Preconditions.checkState(mayGetIterator,
           "DirectoryStream can only have one iterator.");
       mayGetIterator = false;

--- a/src/com/google/enterprise/adaptor/fs/FileDelegate.java
+++ b/src/com/google/enterprise/adaptor/fs/FileDelegate.java
@@ -14,6 +14,7 @@
 
 package com.google.enterprise.adaptor.fs;
 
+import com.google.common.base.Preconditions;
 import com.google.enterprise.adaptor.AsyncDocIdPusher;
 import com.google.enterprise.adaptor.DocId;
 
@@ -25,6 +26,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
+import java.util.Iterator;
 
 interface FileDelegate {
   /**
@@ -204,4 +206,29 @@ interface FileDelegate {
    * terminating any file system change monitors.
    */
   void destroy();
+
+  /**
+   * Helper class for wrapping a collection of {@link Path} as a
+   * {@link DirectoryStream}.
+   */
+  abstract static class AbstractPathDirectoryStream
+      implements DirectoryStream<Path> {
+    protected Iterable<Path> paths;
+    private boolean mayGetIterator = true;
+
+    @Override
+    public Iterator<Path> iterator() {
+      Preconditions.checkState(paths != null,
+          "Iterable paths field must be set.");
+      Preconditions.checkState(mayGetIterator,
+          "DirectoryStream can only have one iterator.");
+      mayGetIterator = false;
+      return paths.iterator();
+    }
+
+    @Override
+    public void close() {
+      mayGetIterator = false;
+    }
+  }
 }

--- a/src/com/google/enterprise/adaptor/fs/WindowsFileDelegate.java
+++ b/src/com/google/enterprise/adaptor/fs/WindowsFileDelegate.java
@@ -49,7 +49,6 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.AclEntry;
 import java.nio.file.attribute.AclFileAttributeView;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -312,10 +311,7 @@ class WindowsFileDelegate extends NioFileDelegate {
     return new DfsLinkDirectoryStream(doc);
   }
 
-  private class DfsLinkDirectoryStream implements DirectoryStream<Path> {
-    private final List<Path> links;
-    private Iterator<Path> iterator;
-
+  private class DfsLinkDirectoryStream extends AbstractPathDirectoryStream {
     public DfsLinkDirectoryStream(Path doc) throws IOException {
       PointerByReference buf = new PointerByReference();
       IntByReference bufSize = new IntByReference();
@@ -340,22 +336,10 @@ class WindowsFileDelegate extends NioFileDelegate {
           }
           bufp = bufp.share(info.size());
         }
-        links = builder.build();
+        paths = builder.build();
       } finally {
         netapi32.NetApiBufferFree(buf.getValue());
       }
-    }
-
-    @Override
-    public Iterator<Path> iterator() {
-      Preconditions.checkState(iterator == null,
-          "DirectoryStream can only have one iterator.");
-      iterator = links.iterator();
-      return iterator;
-    }
-
-    @Override
-    public void close() {
     }
   }
 

--- a/src/com/google/enterprise/adaptor/fs/WindowsFileDelegate.java
+++ b/src/com/google/enterprise/adaptor/fs/WindowsFileDelegate.java
@@ -307,40 +307,34 @@ class WindowsFileDelegate extends NioFileDelegate {
   }
 
   @Override
-  public DirectoryStream<Path> newDfsLinkStream(final Path doc)
-      throws IOException {
-    return new PathDirectoryStream() {
-      @Override
-      public Iterable<Path> getPaths() throws IOException {
-        PointerByReference buf = new PointerByReference();
-        IntByReference bufSize = new IntByReference();
+  public DirectoryStream<Path> newDfsLinkStream(Path doc) throws IOException {
+    PointerByReference buf = new PointerByReference();
+    IntByReference bufSize = new IntByReference();
 
-        int rc = netapi32.NetDfsEnum(doc.toString(), 1, -1, buf, bufSize, null);
-        if (rc != LMErr.NERR_Success) {
-          throw new IOException("Unable to enumerate DFS links for " + doc
-              + ". Code: " + rc);
-        }
+    int rc = netapi32.NetDfsEnum(doc.toString(), 1, -1, buf, bufSize, null);
+    if (rc != LMErr.NERR_Success) {
+      throw new IOException("Unable to enumerate DFS links for " + doc
+          + " Code: " + rc);
+    }
 
-        int numLinks = bufSize.getValue();
-        ImmutableList.Builder<Path> builder = ImmutableList.builder();
-        try {
-          Pointer bufp = buf.getValue();
-          for (int i = 0; i < numLinks; i++) {
-            Netapi32Ex.DFS_INFO_1 info = new Netapi32Ex.DFS_INFO_1(bufp);
-            Path path = Paths.get(info.EntryPath.toString());
-            // NetDfsEnum includes the namespace itself in the enumeration. The
-            // namespace has a nameCount of 0, the links have a nameCount > 0.
-            if (path.getNameCount() > 0) {
-              builder.add(preserveOriginalNamespace(doc, path));
-            }
-            bufp = bufp.share(info.size());
-          }
-          return builder.build();
-        } finally {
-          netapi32.NetApiBufferFree(buf.getValue());
+    int numLinks = bufSize.getValue();
+    ImmutableList.Builder<Path> builder = ImmutableList.builder();
+    try {
+      Pointer bufp = buf.getValue();
+      for (int i = 0; i < numLinks; i++) {
+        Netapi32Ex.DFS_INFO_1 info = new Netapi32Ex.DFS_INFO_1(bufp);
+        Path path = Paths.get(info.EntryPath.toString());
+        // NetDfsEnum includes the namespace itself in the enumeration. The
+        // namespace has a nameCount of 0, the links have a nameCount > 0.
+        if (path.getNameCount() > 0) {
+          builder.add(preserveOriginalNamespace(doc, path));
         }
+        bufp = bufp.share(info.size());
       }
-    };
+      return new PathDirectoryStream(builder.build());
+    } finally {
+      netapi32.NetApiBufferFree(buf.getValue());
+    }
   }
 
   /*

--- a/src/com/google/enterprise/adaptor/fs/WindowsFileDelegate.java
+++ b/src/com/google/enterprise/adaptor/fs/WindowsFileDelegate.java
@@ -307,40 +307,40 @@ class WindowsFileDelegate extends NioFileDelegate {
   }
 
   @Override
-  public DirectoryStream<Path> newDfsLinkStream(Path doc) throws IOException {
-    return new DfsLinkDirectoryStream(doc);
-  }
+  public DirectoryStream<Path> newDfsLinkStream(final Path doc)
+      throws IOException {
+    return new PathDirectoryStream() {
+      @Override
+      public Iterable<Path> getPaths() throws IOException {
+        PointerByReference buf = new PointerByReference();
+        IntByReference bufSize = new IntByReference();
 
-  private class DfsLinkDirectoryStream extends AbstractPathDirectoryStream {
-    public DfsLinkDirectoryStream(Path doc) throws IOException {
-      PointerByReference buf = new PointerByReference();
-      IntByReference bufSize = new IntByReference();
-
-      int rc = netapi32.NetDfsEnum(doc.toString(), 1, -1, buf, bufSize, null);
-      if (rc != LMErr.NERR_Success) {
-        throw new IOException("Unable to enumerate DFS links for " + doc
-            + ". Code: " + rc);
-      }
-
-      int numLinks = bufSize.getValue();
-      ImmutableList.Builder<Path> builder = ImmutableList.builder();
-      try {
-        Pointer bufp = buf.getValue();
-        for (int i = 0; i < numLinks; i++) {
-          Netapi32Ex.DFS_INFO_1 info = new Netapi32Ex.DFS_INFO_1(bufp);
-          Path path = Paths.get(info.EntryPath.toString());
-          // NetDfsEnum includes the namespace itself in the enumeration. The
-          // namespace has a nameCount of 0, the links have a nameCount > 0.
-          if (path.getNameCount() > 0) {
-            builder.add(preserveOriginalNamespace(doc, path));
-          }
-          bufp = bufp.share(info.size());
+        int rc = netapi32.NetDfsEnum(doc.toString(), 1, -1, buf, bufSize, null);
+        if (rc != LMErr.NERR_Success) {
+          throw new IOException("Unable to enumerate DFS links for " + doc
+              + ". Code: " + rc);
         }
-        paths = builder.build();
-      } finally {
-        netapi32.NetApiBufferFree(buf.getValue());
+
+        int numLinks = bufSize.getValue();
+        ImmutableList.Builder<Path> builder = ImmutableList.builder();
+        try {
+          Pointer bufp = buf.getValue();
+          for (int i = 0; i < numLinks; i++) {
+            Netapi32Ex.DFS_INFO_1 info = new Netapi32Ex.DFS_INFO_1(bufp);
+            Path path = Paths.get(info.EntryPath.toString());
+            // NetDfsEnum includes the namespace itself in the enumeration. The
+            // namespace has a nameCount of 0, the links have a nameCount > 0.
+            if (path.getNameCount() > 0) {
+              builder.add(preserveOriginalNamespace(doc, path));
+            }
+            bufp = bufp.share(info.size());
+          }
+          return builder.build();
+        } finally {
+          netapi32.NetApiBufferFree(buf.getValue());
+        }
       }
-    }
+    };
   }
 
   /*

--- a/test/com/google/enterprise/adaptor/fs/MockFile.java
+++ b/test/com/google/enterprise/adaptor/fs/MockFile.java
@@ -332,18 +332,13 @@ class MockFile {
     if (!isDirectory) {
       throw new NotDirectoryException("not a directory " + getPath());
     }
-    return new PathDirectoryStream() {
-      @Override
-      public Iterable<Path> getPaths() {
-        // TODO(bmj): Use ImmutableSortedMultiset after upgrading guava.
-        ArrayList<Path> paths = new ArrayList<Path>();
-        for (MockFile file : directoryContents) {
-          paths.add(Paths.get(file.getPath()));
-        }
-        Collections.sort(paths);
-        return Collections.unmodifiableList(paths);
-      }
-    };
+    // TODO(bmj): Use ImmutableSortedMultiset after upgrading guava.
+    ArrayList<Path> paths = new ArrayList<Path>();
+    for (MockFile file : directoryContents) {
+      paths.add(Paths.get(file.getPath()));
+    }
+    Collections.sort(paths);
+    return new PathDirectoryStream(Collections.unmodifiableList(paths));
   }
 
   @Override

--- a/test/com/google/enterprise/adaptor/fs/MockFile.java
+++ b/test/com/google/enterprise/adaptor/fs/MockFile.java
@@ -15,12 +15,14 @@
 package com.google.enterprise.adaptor.fs;
 
 import static com.google.enterprise.adaptor.fs.AclView.group;
+import static com.google.enterprise.adaptor.fs.FileDelegate.AbstractPathDirectoryStream;
 import static java.nio.file.attribute.AclEntryFlag.*;
 import static java.nio.file.attribute.AclEntryPermission.*;
 import static java.nio.file.attribute.AclEntryType.*;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSortedSet;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
@@ -34,7 +36,6 @@ import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -391,28 +392,14 @@ class MockFile {
     }
   }
 
-  private class MockDirectoryStream implements DirectoryStream<Path> {
-    private Iterator<Path> iterator;
-
+  private class MockDirectoryStream extends AbstractPathDirectoryStream {
     MockDirectoryStream(List<MockFile> files) {
-      ArrayList<Path> paths = new ArrayList<Path>();
+      ImmutableSortedSet.Builder<Path> builder =
+          ImmutableSortedSet.naturalOrder();
       for (MockFile file : files) {
-        paths.add(Paths.get(file.getPath()));
+        builder.add(Paths.get(file.getPath()));
       }
-      Collections.sort(paths);
-      iterator = paths.iterator();
+      paths = builder.build();
     }
-
-    @Override
-    public Iterator<Path> iterator() {
-      Preconditions.checkState(iterator != null,
-          "multiple attempts to get iterator");
-      Iterator<Path> rtn = iterator;
-      iterator = null;
-      return rtn;
-    }
-
-    @Override
-    public void close() {}
   }
 }

--- a/test/com/google/enterprise/adaptor/fs/MockFileDelegate.java
+++ b/test/com/google/enterprise/adaptor/fs/MockFileDelegate.java
@@ -182,18 +182,13 @@ class MockFileDelegate implements FileDelegate {
     if (!file.isDfsNamespace()) {
       throw new IOException("Not a DFS Root: " + doc);
     }
-    return new PathDirectoryStream() {
-      @Override
-      public Iterable<Path> getPaths() throws IOException {
-        ImmutableList.Builder<Path> builder = ImmutableList.builder();
-        for (Path path : file.newDirectoryStream()) {
-          if (isDfsLink(path)) {
-            builder.add(path);
-          }
-        }
-        return builder.build();
+    ImmutableList.Builder<Path> builder = ImmutableList.builder();
+    for (Path path : file.newDirectoryStream()) {
+      if (isDfsLink(path)) {
+        builder.add(path);
       }
-    };
+    }
+    return new PathDirectoryStream(builder.build());
   }
 
   @Override

--- a/test/com/google/enterprise/adaptor/fs/MockFileDelegate.java
+++ b/test/com/google/enterprise/adaptor/fs/MockFileDelegate.java
@@ -178,7 +178,7 @@ class MockFileDelegate implements FileDelegate {
 
   @Override
   public DirectoryStream<Path> newDfsLinkStream(Path doc) throws IOException {
-    final MockFile file = getFile(doc);
+    MockFile file = getFile(doc);
     if (!file.isDfsNamespace()) {
       throw new IOException("Not a DFS Root: " + doc);
     }

--- a/test/com/google/enterprise/adaptor/fs/NioFileDelegateTest.java
+++ b/test/com/google/enterprise/adaptor/fs/NioFileDelegateTest.java
@@ -37,7 +37,6 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
-import java.util.List;
 import java.util.Set;
 
 /** Tests for {@link NioFileDelegate} */
@@ -254,7 +253,7 @@ public class NioFileDelegateTest {
     }
 
     @Override
-    public List<Path> enumerateDfsLinks(Path doc) throws IOException {
+    public DirectoryStream<Path> newDfsLinkStream(Path doc) throws IOException {
       throw new UnsupportedOperationException();
     }
   }

--- a/test/com/google/enterprise/adaptor/fs/WindowsFileDelegateTest.java
+++ b/test/com/google/enterprise/adaptor/fs/WindowsFileDelegateTest.java
@@ -683,13 +683,7 @@ public class WindowsFileDelegateTest extends TestWindowsAclViews {
     WindowsFileDelegate delegate =
         new WindowsFileDelegate(null, null, netapi, null, 0);
     Path namespace = Paths.get("\\\\host\\namespace");
-    ImmutableList.Builder<Path> builder = ImmutableList.builder();
-    try (DirectoryStream<Path> links = delegate.newDfsLinkStream(namespace)) {
-      for (Path link : links) {
-        builder.add(link);
-      }
-    }
-    return builder.build();
+    return ImmutableList.copyOf(delegate.newDfsLinkStream(namespace));
   }
 
   @Test

--- a/test/com/google/enterprise/adaptor/fs/WindowsFileDelegateTest.java
+++ b/test/com/google/enterprise/adaptor/fs/WindowsFileDelegateTest.java
@@ -682,7 +682,14 @@ public class WindowsFileDelegateTest extends TestWindowsAclViews {
 
     WindowsFileDelegate delegate =
         new WindowsFileDelegate(null, null, netapi, null, 0);
-    return delegate.enumerateDfsLinks(Paths.get("\\\\host\\namespace"));
+    Path namespace = Paths.get("\\\\host\\namespace");
+    ImmutableList.Builder<Path> builder = ImmutableList.builder();
+    try (DirectoryStream<Path> links = delegate.newDfsLinkStream(namespace)) {
+      for (Path link : links) {
+        builder.add(link);
+      }
+    }
+    return builder.build();
   }
 
   @Test


### PR DESCRIPTION
This is done to eventually unify the crawling of DFS Links and
ordinary directories in getDocContent().