### PR TITLE
Fix b/28133136: Change notifications cease after file server reboot

### DIFF
--- a/src/com/google/enterprise/adaptor/fs/WindowsFileDelegate.java
+++ b/src/com/google/enterprise/adaptor/fs/WindowsFileDelegate.java
@@ -490,10 +490,11 @@ class WindowsFileDelegate extends NioFileDelegate {
             log.log(Level.FINE, "Terminate event has been received; ending file"
                 + " monitor for {0}.", watchPath);
             break;
-          } else if (waitResult == WinBase.WAIT_FAILED) {
-            log.log(Level.FINE, "Wait failure; ending file monitor for {0}. "
-                + "GetLastError: {1}",
-                new Object[] { watchPath, kernel32.GetLastError() });
+          } else {
+            log.log(Level.WARNING,
+                "Unexpected result from WaitForSingleObjectEx: {0}. "
+                 + "GetLastError: {1}. Ending file monitor for {2}.",
+                 new Object[] {waitResult, kernel32.GetLastError(), watchPath});
             break;
           }
         } finally {
@@ -594,12 +595,6 @@ class WindowsFileDelegate extends NioFileDelegate {
           if (logging) {
             log.log(Level.FINER, "A notification was sent to the monitor "
                 + "callback for {0}.", watchPath);
-          }
-          continue;
-        } else if (waitResult == Kernel32.WAIT_TIMEOUT) {
-          if (logging) {
-            log.log(Level.FINER, "Timed out waiting for notifications from {0}."
-                + " Retrying.", watchPath);
           }
           continue;
         } else if (waitResult == WinBase.WAIT_OBJECT_0) {

--- a/test/com/google/enterprise/adaptor/fs/WindowsFileDelegateTest.java
+++ b/test/com/google/enterprise/adaptor/fs/WindowsFileDelegateTest.java
@@ -37,6 +37,7 @@ import com.sun.jna.platform.win32.Advapi32;
 import com.sun.jna.platform.win32.LMErr;
 import com.sun.jna.platform.win32.W32Errors;
 import com.sun.jna.platform.win32.Win32Exception;
+import com.sun.jna.platform.win32.WinBase;
 import com.sun.jna.platform.win32.WinDef.ULONG;
 import com.sun.jna.platform.win32.WinError;
 import com.sun.jna.platform.win32.WinNT;
@@ -934,6 +935,113 @@ public class WindowsFileDelegateTest extends TestWindowsAclViews {
     Files.write(file5, contents);
     checkForChanges(pusher, Collections.singleton(newRecord(file5)));
     delegate.destroy();
+  }
+
+  @Test
+  public void testMonitorBackOffOnError() throws Exception {
+    Path file1 = newTempFile(tempRoot, "test1.txt");
+    Path file2 = newTempFile(tempRoot, "test2.txt");
+    Path file3 = newTempFile(tempRoot, "test3.txt");
+    byte[] contents = "Hello World".getBytes("UTF-8");
+
+    // Delegate with a Kernel32Ex that fails ReadDirectoryChangesW.
+    Kernel32Ex kernel32 =
+        new ChangeFailingKernel32(Kernel32Ex.INSTANCE, 0, 64, 64, 53);
+
+    WindowsFileDelegate delegate =
+        new WindowsFileDelegate(null, kernel32, null, null, 2000);
+
+    delegate.startMonitorPath(tempRoot, pusher);
+
+    Files.write(file1, contents);
+    checkForChanges(Collections.singleton(newRecord(file1)));
+
+    // This should be missed during the ReadDirectoryChangesW errors
+    Files.write(file2, contents);
+
+    // Wait for the error BackOffs to expire.
+    Thread.sleep(2500);
+
+    // Monitoring should be re-enabled, so this one should go through.
+    Files.write(file3, contents);
+    checkForChanges(Collections.singleton(newRecord(file3)));
+    delegate.destroy();
+  }
+
+  /**
+   * A Kernel32 implementation that returns one of the specified error codes on
+   * each call to ReadDirectoryChangesW. A non-zero return code indicates the
+   * call will fail, and the code will be returned by GetLastError. A return
+   * code of 0 indicates call success, and the delegate's ReadDirectoryChangesW
+   * is called.
+   */
+  private class ChangeFailingKernel32 extends UnsupportedKernel32 {
+    private final Kernel32Ex delegate;
+    private final int[] codes;
+    int index;
+    int lastError;
+
+    public ChangeFailingKernel32(Kernel32Ex delegate, int... codes) {
+      this.delegate = delegate;
+      this.codes = codes;
+      index = 0;
+      lastError = Integer.MAX_VALUE;
+    }
+
+    @Override
+    public boolean ReadDirectoryChangesW(HANDLE handle,
+        FILE_NOTIFY_INFORMATION info, int length, boolean watchSubtree,
+        int notifyFilter, IntByReference bytesReturned, OVERLAPPED overlapped,
+        OVERLAPPED_COMPLETION_ROUTINE completionRoutine) {
+      if (index < codes.length && codes[index] != 0) {
+        lastError = codes[index++];
+        return false;
+      }
+      index++;
+      return delegate.ReadDirectoryChangesW(handle, info, length, watchSubtree,
+          notifyFilter, bytesReturned, overlapped, completionRoutine);
+    }
+
+    @Override
+    public int GetLastError() {
+      if (lastError == Integer.MAX_VALUE) {
+        return delegate.GetLastError();
+      } else {
+        int error = lastError;
+        lastError = Integer.MAX_VALUE;
+        return error;
+      }
+    }
+
+    @Override
+    public HANDLE CreateFile(String fileName, int access, int mode,
+        WinBase.SECURITY_ATTRIBUTES attrs, int disposition, int flags,
+        HANDLE templateFile) {
+      return delegate.CreateFile(fileName, access, mode, attrs, disposition,
+          flags, templateFile);
+    }
+
+    @Override
+    public HANDLE CreateEvent(WinBase.SECURITY_ATTRIBUTES attrs,
+        boolean manualReset, boolean initialState, String name) {
+      return delegate.CreateEvent(attrs, manualReset, initialState, name);
+    }
+
+    @Override
+    public boolean SetEvent(HANDLE handle) {
+      return delegate.SetEvent(handle);
+    }
+
+    @Override
+    public boolean CloseHandle(HANDLE handle) {
+      return delegate.CloseHandle(handle);
+    }
+
+    @Override
+    public int WaitForSingleObjectEx(HANDLE handle, int milliseconds,
+        boolean alertable) {
+      return delegate.WaitForSingleObjectEx(handle, milliseconds, alertable);
+    }
   }
 
   private void checkForChanges(Set<DocIdPusher.Record> expected)

--- a/test/com/google/enterprise/adaptor/fs/WindowsFileDelegateTest.java
+++ b/test/com/google/enterprise/adaptor/fs/WindowsFileDelegateTest.java
@@ -947,10 +947,8 @@ public class WindowsFileDelegateTest extends TestWindowsAclViews {
     // Delegate with a Kernel32Ex that fails ReadDirectoryChangesW.
     Kernel32Ex kernel32 =
         new ChangeFailingKernel32(Kernel32Ex.INSTANCE, 0, 64, 64, 53);
-
     WindowsFileDelegate delegate =
-        new WindowsFileDelegate(null, kernel32, null, null, 2000);
-
+        new WindowsFileDelegate(null, kernel32, null, null, 0);
     delegate.startMonitorPath(tempRoot, pusher);
 
     Files.write(file1, contents);
@@ -959,7 +957,7 @@ public class WindowsFileDelegateTest extends TestWindowsAclViews {
     // This should be missed during the ReadDirectoryChangesW errors
     Files.write(file2, contents);
 
-    // Wait for the error BackOffs to expire.
+    // Wait for the 3 error BackOffs to expire (0.5 + 0.75 + 1.125 = 2.375)
     Thread.sleep(2500);
 
     // Monitoring should be re-enabled, so this one should go through.
@@ -971,9 +969,8 @@ public class WindowsFileDelegateTest extends TestWindowsAclViews {
   /**
    * A Kernel32 implementation that returns one of the specified error codes on
    * each call to ReadDirectoryChangesW. A non-zero return code indicates the
-   * call will fail, and the code will be returned by GetLastError. A return
-   * code of 0 indicates call success, and the delegate's ReadDirectoryChangesW
-   * is called.
+   * call will fail, and the code will be returned by GetLastError. A code of 0
+   * indicates the delegate's ReadDirectoryChangesW should be called.
    */
   private class ChangeFailingKernel32 extends UnsupportedKernel32 {
     private final Kernel32Ex delegate;


### PR DESCRIPTION
If the file server gets rebooted, the connector stops receiving
change notifictions. Any IOExceptions thrown out of the monitor
would kill the monitor thread. This change handles IOExceptions
in the thread, and retrys the monitor with an exponential backoff.

This change also adds a 15 minute timeout to the monitor thread
when waiting for change notifications from the filesystem, in case
the server off-line goes unnoticed while waiting.