### PR TITLE
Add bootclasspath flag to javac.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 dist/
 adaptor-config.properties
+build.properties
 cacerts.jks
 keys.jks
 adaptor.crt

--- a/build.properties.sample
+++ b/build.properties.sample
@@ -1,0 +1,11 @@
+##
+# These properties are specific to the individual's development environment.
+#
+
+# Default JDK 7 installation location for Mac OS X.
+jdk7.home = /Library/Java/JavaVirtualMachines/jdk1.7.0_76.jdk/Contents/Home
+
+# JDK 7 bootclasspath.
+build.bootclasspath = ${jdk7.home}/jre/lib/rt.jar\
+    :${jdk7.home}/jre/lib/jsse.jar\
+    :${jdk7.home}/jre/lib/jce.jar

--- a/build.xml
+++ b/build.xml
@@ -30,6 +30,11 @@
   <!-- If adaptor.version isn't set, simply use the current date. -->
   <property name="adaptor.suffix" value="-${DSTAMP}"/>
 
+  <!-- Load build environment specific properties. -->
+  <property file="build.properties"/>
+  <property name="compile.java.version" value="7"/>
+  <property name="compile.java.bootclasspath" value="${build.bootclasspath}"/>
+
   <path id="adaptor.build.classpath">
     <fileset dir="${lib.dir}">
       <include name="jna.jar"/>
@@ -106,7 +111,9 @@ lib/plexi submodule or add the the command line argument
     <mkdir dir="${build-src.dir}"/>
 
     <javac srcdir="${src.dir}" destdir="${build-src.dir}" debug="true"
-      includeantruntime="false" encoding="utf-8" target="1.7" source="1.7">
+      includeantruntime="false" encoding="utf-8"
+      source="${compile.java.version}" target="${compile.java.version}">
+      <bootclasspath path="${compile.java.bootclasspath}"/>
       <compilerarg value="-Xlint"/>
       <compilerarg value="-Xlint:-serial"/>
       <classpath refid="adaptor.build.classpath"/>
@@ -115,7 +122,9 @@ lib/plexi submodule or add the the command line argument
     <mkdir dir="${build-test.dir}"/>
     <!-- Compile JUnit helper -->
     <javac srcdir="${lib.dir}" destdir="${build-test.dir}" debug="true"
-      includeantruntime="true" encoding="utf-8" target="1.7" source="1.7">
+      includeantruntime="true" encoding="utf-8"
+      source="${compile.java.version}" target="${compile.java.version}">
+      <bootclasspath path="${compile.java.bootclasspath}"/>
       <compilerarg value="-Xlint:unchecked"/>
       <classpath location="${junit.jar}"/>
       <include name="JUnitLogFixFormatter.java"/>
@@ -123,7 +132,9 @@ lib/plexi submodule or add the the command line argument
 
     <!-- Compile tests, excluding example tests. -->
     <javac srcdir="${test.dir}" destdir="${build-test.dir}" debug="true"
-      includeantruntime="false" encoding="utf-8" target="1.7" source="1.7">
+      includeantruntime="false" encoding="utf-8"
+      source="${compile.java.version}" target="${compile.java.version}">
+      <bootclasspath path="${compile.java.bootclasspath}"/>
       <compilerarg value="-Xlint"/>
       <classpath refid="adaptor.build.classpath"/>
       <classpath location="${build-src.dir}"/>


### PR DESCRIPTION
The source, target, and bootclasspath flags must be used together.

Use build.properties file for developer-specific build.bootclasspath
property.